### PR TITLE
Implement missing evocation effects

### DIFF
--- a/features/tile-system/components/PlayerRack.tsx
+++ b/features/tile-system/components/PlayerRack.tsx
@@ -32,6 +32,8 @@ export const PlayerRack: React.FC<PlayerRackProps> = ({
   const [selectedForExchange, setSelectedForExchange] = useState<Set<string>>(new Set());
   const [powerUpModalOpen, setPowerUpModalOpen] = useState(false);
   const [activatingPowerUpType, setActivatingPowerUpType] = useState<PowerUpType | null>(null);
+  const [evocationModalOpen, setEvocationModalOpen] = useState(false);
+  const [activatingEvocation, setActivatingEvocation] = useState<Evocation | null>(null);
   const [showSpells, setShowSpells] = useState(false);
   
   const player = useGameStore((state) => state.players.find(p => p.id === playerId));
@@ -166,10 +168,14 @@ export const PlayerRack: React.FC<PlayerRackProps> = ({
 
     // Play evocation sound
     soundService.playEvocation(evocation.type);
-
-    const success = socketService.activateEvocation(evocation.id);
-    if (!success) {
-      console.error('Failed to activate evocation');
+    if (evocation.type === 'DANTALION') {
+      setActivatingEvocation(evocation);
+      setEvocationModalOpen(true);
+    } else {
+      const success = socketService.activateEvocation(evocation.id);
+      if (!success) {
+        console.error('Failed to activate evocation');
+      }
     }
   };
 
@@ -263,6 +269,19 @@ export const PlayerRack: React.FC<PlayerRackProps> = ({
     setActivatingPowerUpType(null);
   };
 
+  const handleEvocationModalConfirm = (selection: any) => {
+    if (activatingEvocation) {
+      socketService.activateEvocation(activatingEvocation.id, selection);
+    }
+    setEvocationModalOpen(false);
+    setActivatingEvocation(null);
+  };
+
+  const handleEvocationModalClose = () => {
+    setEvocationModalOpen(false);
+    setActivatingEvocation(null);
+  };
+
   const getOpponent = () => {
     return players.find(p => p.id !== playerId);
   };
@@ -342,6 +361,8 @@ export const PlayerRack: React.FC<PlayerRackProps> = ({
                 tile.isPowerUp ? 'power-up-tile' : ''
               } ${
                 tile.isBlank ? 'blank-tile' : ''
+              } ${
+                player.silencedTiles?.includes(tile.id) ? 'silenced' : ''
               } ${
                 isAIPlayer() && !tile.isPowerUp ? 'ai-tile' : ''
               }`}
@@ -577,6 +598,19 @@ export const PlayerRack: React.FC<PlayerRackProps> = ({
         opponent={getOpponent()}
         board={board}
       />
+
+      {/* Evocation Modal (reuse PowerUpModal for selection) */}
+      {activatingEvocation && (
+        <PowerUpModal
+          isOpen={evocationModalOpen}
+          powerUpType="DUPLICATE"
+          onClose={handleEvocationModalClose}
+          onConfirm={handleEvocationModalConfirm}
+          player={player}
+          opponent={getOpponent()}
+          board={board}
+        />
+      )}
     </div>
   );
 };

--- a/features/tile-system/components/PowerUpModal.tsx
+++ b/features/tile-system/components/PowerUpModal.tsx
@@ -110,7 +110,7 @@ export const PowerUpModal: React.FC<PowerUpModalProps> = ({
               {opponent?.tiles.map((tile) => (
                 <div
                   key={tile.id}
-                  className={`tile-option ${selectedTiles.includes(tile.id) ? 'selected' : ''}`}
+                  className={`tile-option ${selectedTiles.includes(tile.id) ? 'selected' : ''} ${opponent?.silencedTiles?.includes(tile.id) ? 'silenced' : ''}`}
                   onClick={() => handleTileSelection(tile.id)}
                 >
                   {tile.letter}
@@ -131,7 +131,7 @@ export const PowerUpModal: React.FC<PowerUpModalProps> = ({
               {opponent?.tiles.map((tile) => (
                 <div
                   key={tile.id}
-                  className={`tile-option ${selectedTiles.includes(tile.id) ? 'selected' : ''}`}
+                  className={`tile-option ${selectedTiles.includes(tile.id) ? 'selected' : ''} ${opponent?.silencedTiles?.includes(tile.id) ? 'silenced' : ''}`}
                   onClick={() => handleTileSelection(tile.id)}
                 >
                   {tile.letter}
@@ -151,7 +151,7 @@ export const PowerUpModal: React.FC<PowerUpModalProps> = ({
               {player.tiles.filter(tile => !tile.isPowerUp).map((tile) => (
                 <div
                   key={tile.id}
-                  className={`tile-option ${selectedTiles.includes(tile.id) ? 'selected' : ''}`}
+                  className={`tile-option ${selectedTiles.includes(tile.id) ? 'selected' : ''} ${player.silencedTiles?.includes(tile.id) ? 'silenced' : ''}`}
                   onClick={() => handleTileSelection(tile.id)}
                 >
                   {tile.letter}

--- a/scrabble-backend/src/events/gameEvents.ts
+++ b/scrabble-backend/src/events/gameEvents.ts
@@ -754,7 +754,7 @@ export function registerGameEvents(socket: Socket, io: Server) {
   });
 
   // Activate evocation
-  socket.on('activate-evocation', async (data: { evocationId: string }) => {
+  socket.on('activate-evocation', async (data: { evocationId: string; params?: any }) => {
     try {
       // Rate limiting
       if (!RateLimiter.checkLimit(socket.id, 'activate-evocation', 2, 5000)) { // 2 per 5 seconds
@@ -829,7 +829,7 @@ export function registerGameEvents(socket: Socket, io: Server) {
           const evocationType = activatedEvocation?.type || 'UNKNOWN';
           
           // Execute evocation-specific effects that require game state access
-          const effectsResult = await gameService.executeEvocationEffects(context.roomId, context.player.id, evocationType);
+          const effectsResult = await gameService.executeEvocationEffects(context.roomId, context.player.id, evocationType, data.params);
           
           if (effectsResult.success) {
             socket.emit('activate-evocation-response', {

--- a/scrabble-backend/src/types/game.ts
+++ b/scrabble-backend/src/types/game.ts
@@ -102,6 +102,7 @@ export interface Player {
   // Intercession effects
   samaelDoubleDamage?: boolean;  // Next word deals double damage
   urielProtection?: boolean;     // 50% damage reduction next turn
+  silencedTiles?: string[];      // Tiles locked for current turn
 }
 
 export interface GameState {

--- a/src/services/socketService.ts
+++ b/src/services/socketService.ts
@@ -269,13 +269,13 @@ export const socketService = {
   },
 
   // Evocation activation
-  activateEvocation: (evocationId: string) => {
+  activateEvocation: (evocationId: string, params: any = {}) => {
     if (!evocationId || typeof evocationId !== 'string') {
       console.error('Client validation failed for activateEvocation: invalid evocation ID');
       return false;
     }
-    
-    socket.emit('activate-evocation', { evocationId });
+
+    socket.emit('activate-evocation', { evocationId, params });
     return true;
   },
 

--- a/types/game.ts
+++ b/types/game.ts
@@ -102,6 +102,7 @@ export interface Player {
   // Intercession effects
   samaelDoubleDamage?: boolean;  // Next word deals double damage
   urielProtection?: boolean;     // 50% damage reduction next turn
+  silencedTiles?: string[];      // Tiles locked for current turn
 }
 
 export interface GameState {


### PR DESCRIPTION
## Summary
- allow Player objects to track silenced tiles
- clear silenced tiles each turn
- implement Dantalion tile duplication and Murmur silence
- support evocation parameters via sockets
- reuse PowerUpModal for Dantalion tile selection
- display silenced tiles in the UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851da3e4af08333a9b115654aa8441f